### PR TITLE
Typo in link

### DIFF
--- a/_games/contact.md
+++ b/_games/contact.md
@@ -85,4 +85,4 @@ Player 1: Is it a person who herds animals?
 It Player: No, it is not a SHEpard.
 
 # Variations
-- If two players mess up a contact, as in they don't say the same words on the count of 3, they immediately start a game of [Mind Meld]({{ site.baseurl }}/games/mind-meld.html) with those two words as the seed words.
+- If two players mess up a contact, as in they don't say the same words on the count of 3, they immediately start a game of [Mind Meld]({{ site.baseurl }}/games/mindmeld.html) with those two words as the seed words.


### PR DESCRIPTION
The link to "Mind Meld" wasn't working. The URL for it actually shouldn't have a dash.